### PR TITLE
Update continuous index in Index.scala

### DIFF
--- a/silk-core/src/main/scala/org/silkframework/entity/Index.scala
+++ b/silk-core/src/main/scala/org/silkframework/entity/Index.scala
@@ -138,7 +138,7 @@ object Index {
   }
 
   def continuous(value: Double, minValue: Double, maxValue: Double, blockCount: Int, overlap: Double): Index = {
-    val block = (value - minValue) * blockCount
+    val block = ((value - minValue)/ (maxValue - minValue) ) * blockCount
     val blockIndex = block.toInt
 
     val indices =


### PR DESCRIPTION
`val block = (value - minValue) * blockCount` would work only for normalaized values (with min=0 and max=1)
for other values, a normalization over the values interval is necessary.
